### PR TITLE
esxcli needs ia32 libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update
 # Install vCLI Pre-Reqs
 RUN apt-get install -yq build-essential \
       gcc \
+      gcc-multilib \
       uuid \
       uuid-dev \
       perl \


### PR DESCRIPTION
Running esxcli yields `bash: /usr/bin/esxcli: No such file or directory`.  Added the ia32 libraries (via gcc-multilib) to resolve the issue.
