### PR TITLE
update filenames for vSphere Perl SDK and OVFTOOL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.sw?
-VMware-ovftool-4.0.0-2301625-lin.x86_64.bundle
-VMware-vSphere-CLI-5.5.0-2043780.x86_64.tar.gz
-VMware-vix-disklib-5.5.4-2454786.x86_64.tar.gz
-cloudclient-3.3.1-2966416-dist.zip
+*.bundle
+*.tar.gz
+*.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /root
 
 #### ---- Installer Files ---- ####
 
-ARG VSPHERE65_SDK_PERL=VMware-vSphere-CLI-6.5.0-4566394.x86_64.tar.gz
+ARG VSPHERE65_SDK_PERL=VMware-vSphere-Perl-SDK-6.5.0-4566394.x86_64.tar.gz
 ARG VSPHERE65_MGMT_SDK=VMware-vSphereSDK-6.5.0-4571253.zip
 ARG VSPHERE65_AUTOMATION_SDK_RUBY=VMware-vSphere-Automation-SDK-Ruby-6.5.0-4571906.zip
 ARG VSPHERE65_AUTOMATION_SDK_PYTHON=VMware-vSphere-Automation-SDK-Python-6.5.0-4571810.zip
@@ -17,7 +17,7 @@ ARG VSAN65_SDK_PYTHON=vsan-sdk-65-python-4602587.zip
 ARG VSAN65_SDK_JAVA=vsan-sdk-65-java-4602587.zip
 ARG VSAN65_SDK_PERL=vsan-sdk-65-perl-4602587.zip
 ARG VDDK65=VMware-vix-disklib-6.5.0-4604867.x86_64.tar.gz
-ARG OVFTOOl42=VMware-ovftool-4.2.0-4586971-lin.x86_64.bundle
+ARG OVFTOOl42=VMware-ovftool-4.2.0-5965791-lin.x86_64.bundle
 ARG VMWARE_UTILS_INSTALLER=vmware-utils-install.sh
 
 ADD [ \

--- a/vmware-utils-install.sh
+++ b/vmware-utils-install.sh
@@ -1,7 +1,7 @@
 
 #### ---- Installer Files ---- ####
 
-VSPHERE65_SDK_PERL=VMware-vSphere-CLI-6.5.0-4566394.x86_64.tar.gz
+VSPHERE65_SDK_PERL=VMware-vSphere-Perl-SDK-6.5.0-4566394.x86_64.tar.gz
 VSPHERE65_MGMT_SDK=VMware-vSphereSDK-6.5.0-4571253.zip
 VSPHERE65_AUTOMATION_SDK_RUBY=VMware-vSphere-Automation-SDK-Ruby-6.5.0-4571906.zip
 VSPHERE65_AUTOMATION_SDK_PYTHON=VMware-vSphere-Automation-SDK-Python-6.5.0-4571810.zip
@@ -12,7 +12,7 @@ VSAN65_SDK_PYTHON=vsan-sdk-65-python-4602587.zip
 VSAN65_SDK_JAVA=vsan-sdk-65-java-4602587.zip
 VSAN65_SDK_PERL=vsan-sdk-65-perl-4602587.zip
 VDDK65=VMware-vix-disklib-6.5.0-4604867.x86_64.tar.gz
-OVFTOOl42=VMware-ovftool-4.2.0-4586971-lin.x86_64.bundle
+OVFTOOl42=VMware-ovftool-4.2.0-5965791-lin.x86_64.bundle
 
 #### ---- Install Package Dependencies ---- ####
 


### PR DESCRIPTION
vSphere perl SDK 6.5 now downloads as
  VMware-vSphere-Perl-SDK-6.5.0-4566394.x86_64.tar.gz
OVFTool 4.2 now dowloads with build number 5965791
updated .gitignore to ignore all .bundle .zip and .tar.gz files

Resolves Issue #15 